### PR TITLE
Add managed_ :: (forall r. IO r -> IO r) -> Managed ()

### DIFF
--- a/src/Control/Monad/Managed.hs
+++ b/src/Control/Monad/Managed.hs
@@ -79,6 +79,7 @@ module Control.Monad.Managed (
     -- * Managed
     Managed,
     managed,
+    managed_,
     with,
     runManaged,
 
@@ -164,6 +165,10 @@ instance Floating a => Floating (Managed a) where
 -- | Build a `Managed` value
 managed :: (forall r . (a -> IO r) -> IO r) -> Managed a
 managed = Managed
+
+-- | Like 'managed' but for resource-less operations.
+managed_ :: (forall r. IO r -> IO r) -> Managed ()
+managed_ f = managed $ \g -> f $ g ()
 
 -- | Acquire a `Managed` value
 with :: Managed a -> (a -> IO r) -> IO r

--- a/src/Control/Monad/Managed/Safe.hs
+++ b/src/Control/Monad/Managed/Safe.hs
@@ -18,6 +18,7 @@ module Control.Monad.Managed.Safe (
     -- * Managed
     Managed,
     managed,
+    managed_,
     runManaged,
 
     -- * Re-exports
@@ -26,7 +27,7 @@ module Control.Monad.Managed.Safe (
     ) where
 
 import Control.Monad.IO.Class (MonadIO(liftIO))
-import Control.Monad.Managed (Managed, managed, runManaged)
+import Control.Monad.Managed (Managed, managed, managed_, runManaged)
 
 {- $reexports
     "Control.Monad.IO.Class" re-exports 'MonadIO'


### PR DESCRIPTION
This is useful for lifting acquire-and-release operations into Managed that don't have an associated resource. For example: `\m -> bracket (forkIO daemon) killThread $ \_tid -> m`