### PR TITLE
Add a Semigroup instance for Managed

### DIFF
--- a/managed.cabal
+++ b/managed.cabal
@@ -35,6 +35,9 @@ Library
     Build-Depends:
         base              >= 4.5     && < 5  ,
         transformers      >= 0.2.0.0 && < 0.6
+    if !impl(ghc >= 8.0)
+      Build-Depends:
+        semigroups        >= 0.16    && < 0.19
     Exposed-Modules:
         Control.Monad.Managed,
         Control.Monad.Managed.Safe

--- a/src/Control/Monad/Managed.hs
+++ b/src/Control/Monad/Managed.hs
@@ -80,7 +80,7 @@
 
 > import Control.Monad
 > import Control.Monad.Managed
-> 
+>
 > main = runManaged (forever (liftIO (print 1)))
 
     If you need to acquire a resource for a long-lived loop, you can instead
@@ -114,7 +114,11 @@ import Control.Monad.Trans.Class (lift)
 import Control.Applicative (liftA2)
 #else
 import Control.Applicative
-import Data.Monoid
+import Data.Monoid (Monoid(..))
+#endif
+
+#if !(MIN_VERSION_base(4,11,0))
+import Data.Semigroup (Semigroup(..))
 #endif
 
 import qualified Control.Monad.Trans.Cont          as Cont
@@ -162,10 +166,15 @@ instance MonadIO Managed where
         a <- m
         return_ a )
 
+instance Semigroup a => Semigroup (Managed a) where
+    (<>) = liftA2 (<>)
+
 instance Monoid a => Monoid (Managed a) where
     mempty = pure mempty
 
+#if !(MIN_VERSION_base(4,11,0))
     mappend = liftA2 mappend
+#endif
 
 instance Num a => Num (Managed a) where
     fromInteger = pure . fromInteger


### PR DESCRIPTION
This is needed to fix the build on GHC 8.4, where `Semigroup` is now a superclass of `Monoid`.