### PR TITLE
Generalize some functions to work on any `MonadManaged` monad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/dist/
+/dist-newstyle/

--- a/src/Control/Monad/Managed.hs
+++ b/src/Control/Monad/Managed.hs
@@ -271,11 +271,11 @@ instance (Monoid w, MonadManaged m) => MonadManaged (Writer.Lazy.WriterT w m) wh
     using m = lift (using m)
 
 -- | Build a `Managed` value
-managed :: (forall r . (a -> IO r) -> IO r) -> Managed a
-managed = Managed
+managed :: MonadManaged m => (forall r . (a -> IO r) -> IO r) -> m a
+managed f = using (Managed f)
 
 -- | Like 'managed' but for resource-less operations.
-managed_ :: (forall r. IO r -> IO r) -> Managed ()
+managed_ :: MonadManaged m => (forall r. IO r -> IO r) -> m ()
 managed_ f = managed $ \g -> f $ g ()
 
 {-| Acquire a `Managed` value


### PR DESCRIPTION
I wanted to convert `with` and `runManaged` too, but I can't write this definition:

```
with :: MonadManaged m => m a -> (a -> IO r) -> IO r
with = ???
```

I can't convert _any_ `MonadManaged` monad into `IO`.

I may take a stab at writing the monad transformer (relevant issue https://github.com/Gabriel439/Haskell-Managed-Library/issues/10) and `MonadTrans` instance in a separate PR, since that would help generalize things further.