### PR TITLE
Generalize functions to accept any `MonadIO` resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/dist/
+/dist-newstyle/

--- a/src/Control/Monad/Managed.hs
+++ b/src/Control/Monad/Managed.hs
@@ -271,11 +271,11 @@ instance (Monoid w, MonadManaged m) => MonadManaged (Writer.Lazy.WriterT w m) wh
     using m = lift (using m)
 
 -- | Build a `Managed` value
-managed :: (forall r . (a -> IO r) -> IO r) -> Managed a
-managed = Managed
+managed :: MonadManaged m => (forall r . (a -> IO r) -> IO r) -> m a
+managed f = using (Managed f)
 
 -- | Like 'managed' but for resource-less operations.
-managed_ :: (forall r. IO r -> IO r) -> Managed ()
+managed_ :: MonadManaged m => (forall r. IO r -> IO r) -> m ()
 managed_ f = managed $ \g -> f $ g ()
 
 {-| Acquire a `Managed` value


### PR DESCRIPTION
This builds on my last PR by generalizing the wrapped monad from `IO` to any monad with an instance of `MonadIO` (and `MonadFail`).

Because the wrapped monad is existentially quantified, I can't write a constrained `MonadFail` instance for `Managed` like this:

```
instance MonadFail m => MonadFail (Managed m) where
```