### PR TITLE
Eta-expand to work with simplified subsumption in GHC 9.

### DIFF
--- a/src/Control/Monad/Managed.hs
+++ b/src/Control/Monad/Managed.hs
@@ -303,7 +303,7 @@ managed_ f = managed $ \g -> f $ g ()
     a value that is not a resource being managed.
 -}
 with :: Managed a -> (a -> IO r) -> IO r
-with = (>>-)
+with m = (>>-) m
 
 -- | Run a `Managed` computation, enforcing that no acquired resources leak
 runManaged :: Managed () -> IO ()


### PR DESCRIPTION
Because of the newly implemented simplified subsumption (https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0287-simplify-subsumption.rst), this package fails to build under GHC 9.  All that's required to fix is to eta-expand one function definition.  With this change, I was able to build under the recent GHC 9.0.1-alpha1.